### PR TITLE
fix: use hyphenated distribution name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pytask_julia"
+name = "pytask-julia"
 description = "A Pytask plugin for Julia"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

- Change the project distribution name from `pytask_julia` to `pytask-julia` in `pyproject.toml`.
- Keep the import package and pytask plugin entry point as `pytask_julia`.

## Why

PyPI displays the distribution name from package metadata in the install command. Python packaging normalizes underscores and hyphens to the same project key, but using the hyphenated distribution name keeps PyPI aligned with the README, repository name, and installation instructions.

## Validation

- pulled current `origin/main` before branching
- confirmed branch merge-base equals `origin/main`
- `uv build`
- inspected generated wheel metadata: `Name: pytask-julia`
- `uv run --group test pytest` passed with 13 passed, 28 skipped
